### PR TITLE
Different color for elevated prompt

### DIFF
--- a/_set.bat
+++ b/_set.bat
@@ -1,10 +1,23 @@
         @echo off
         for %%a in ("%CD%") do set "PARENT_FOLDER=%%~nxa"
         title %PARENT_FOLDER%
+
         set GITBRANCH=
         for /f "tokens=2" %%I in ('git.exe branch 2^> NUL ^| findstr /b "* "') do set GITBRANCH=%%I
-        if "%GITBRANCH%" == "" (
-            prompt $E[30;44m$S$E[0m$E[30;44m$P$S$E[0m$E[34m$E[0m$S
+
+        set ELEVATED=
+        net.exe session 1>NUL 2>NUL && set ELEVATED=1
+
+        if "%ELEVATED%" == "" (
+            if "%GITBRANCH%" == "" (
+                prompt $E[30;44m$S$E[0m$E[30;44m$P$S$E[0m$E[34m$E[0m$S
+            ) else (
+                prompt $E[30;44m$S$E[0m$E[30;44m$P$S$E[0m$E[34;43m$S$E[0m$E[30;43m%GITBRANCH%$S$E[0m$E[33m$E[0m$S
+            )
         ) else (
-            prompt $E[30;44m$S$E[0m$E[30;44m$P$S$E[0m$E[34;43m$S$E[0m$E[30;43m%GITBRANCH%$S$E[0m$E[33m$E[0m$S
+            if "%GITBRANCH%" == "" (
+                prompt $E[30;41m$S$E[0m$E[30;41m$P$S$E[0m$E[31m$E[0m$S
+            ) else (
+                prompt $E[30;41m$S$E[0m$E[30;41m$P$S$E[0m$E[31;43m$S$E[0m$E[30;43m%GITBRANCH%$S$E[0m$E[33m$E[0m$S
+            )
         )


### PR DESCRIPTION
Use a red color when running `cmd.exe` in an elevated context with `Administrator` privileges. This is similar to what many common Powerline configurations do on Linux (show the command prompt in red for the `root` user).

Screenshots of both a non-elevated and an elevated command line:
![powerline-elevated](https://user-images.githubusercontent.com/2482377/199018371-f9d718f8-a43b-4d71-a105-60536a78de16.png)
