### PR TITLE
Configure .bat files to use CRLF line ends

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bat text eol=crlf


### PR DESCRIPTION
Configure git so it checks out .bat files with Windows-style line endings (so cmd.exe does not complain about them).